### PR TITLE
Add Skill Hub — 5800+ AI Agent Skills Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5156,3 +5156,7 @@ openclaw skill install self-improving-agent
 ### 贡献与反馈
 
 如发现技能描述有误或希望补充新技能，欢迎提交 Issue 或 Pull Request。
+
+
+## Related Resources
+- [Skill Hub](https://skill.442595.xyz/) — 5800+ curated AI Agent Skills for Claude Code, Codex, Cursor, Hermes & more across 22 categories.


### PR DESCRIPTION
Add [Skill Hub](https://skill.442595.xyz/) — a free directory of 5800+ curated AI agent skills for Claude Code, Codex, Cursor, Hermes, OpenClaw & more across 22 categories.